### PR TITLE
Add ALIAS support

### DIFF
--- a/octodns_bunny/BunnyDNSClient.py
+++ b/octodns_bunny/BunnyDNSClient.py
@@ -186,7 +186,6 @@ class BunnyDNSClient(object):
         type_map = {
             "A": 0,
             "AAAA": 1,
-            "ALIAS": 2,  # Supported, but called CNAME in BunnyDNS
             "CNAME": 2,
             "TXT": 3,
             "MX": 4,
@@ -201,6 +200,10 @@ class BunnyDNSClient(object):
         }
         if reverse:
             type_map = {v: k for k, v in type_map.items()}
+        else:
+            # ALIAS record on root label is supported,
+            # but called CNAME in BunnyDNS
+            type_map["ALIAS"] = type_map["CNAME"]
         type_mapped = type_map[type]
         return type_mapped
 

--- a/octodns_bunny/BunnyDNSClient.py
+++ b/octodns_bunny/BunnyDNSClient.py
@@ -182,7 +182,7 @@ class BunnyDNSClient(object):
         else:
             return domain_id
 
-    def _map_record_type_to_string(self, type, reverse=False):
+    def _map_record_type_to_string(self, type, reverse=False, name=None):
         type_map = {
             "A": 0,
             "AAAA": 1,
@@ -200,6 +200,10 @@ class BunnyDNSClient(object):
         }
         if reverse:
             type_map = {v: k for k, v in type_map.items()}
+            # Mapping back Bunny's CNAME to OctoDNS ALIAS record,
+            # but only for the root label (name is an empty string)
+            if isinstance(name, str) and not len(name):
+                type_map[2] = "ALIAS"
         else:
             # ALIAS record on root label is supported,
             # but called CNAME in BunnyDNS
@@ -214,7 +218,7 @@ class BunnyDNSClient(object):
         fixed_records = []
         for record in domain_contents["Records"]:
             record["Type"] = self._map_record_type_to_string(
-                record["Type"], reverse=True
+                record["Type"], reverse=True, name=record["Name"]
             )
             fixed_records.append(record)
 

--- a/octodns_bunny/BunnyDNSClient.py
+++ b/octodns_bunny/BunnyDNSClient.py
@@ -186,6 +186,7 @@ class BunnyDNSClient(object):
         type_map = {
             "A": 0,
             "AAAA": 1,
+            "ALIAS": 2,  # Supported, but called CNAME in BunnyDNS
             "CNAME": 2,
             "TXT": 3,
             "MX": 4,

--- a/octodns_bunny/__init__.py
+++ b/octodns_bunny/__init__.py
@@ -38,6 +38,11 @@ class BunnyDNSProvider(BaseProvider):
             "values": [r["Value"] for r in records],
         }
 
+    def _data_for_ALIAS(self, _type, records):
+        # Bunny DNS supports CNAME on root label, so let's fall through
+        # We should probably check if this is the root label (`@`)
+        return self._data_for_CNAME(_type=_type, records=records)
+
     def _data_for_CNAME(self, _type, records):
         # We can only have one value for CNAME
         record = records[0]
@@ -118,6 +123,10 @@ class BunnyDNSProvider(BaseProvider):
                 "Ttl": record.ttl,
                 "Type": record._type,
             }
+
+    def _params_for_ALIAS(self, record):
+        # Fall through to CNAME
+        return self._params_for_CNAME(record=record)
 
     def _params_for_CNAME(self, record):
         yield {

--- a/octodns_bunny/__init__.py
+++ b/octodns_bunny/__init__.py
@@ -14,7 +14,18 @@ class BunnyDNSProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     SUPPORTS_ROOT_NS = True
-    SUPPORTS = {"A", "AAAA", "CNAME", "TXT", "MX", "SRV", "CAA", "PTR", "NS"}
+    SUPPORTS = {
+        "A",
+        "AAAA",
+        "ALIAS",
+        "CNAME",
+        "TXT",
+        "MX",
+        "SRV",
+        "CAA",
+        "PTR",
+        "NS",
+    }
 
     def __init__(self, id, token, *args, **kwargs):
         self.log = logging.getLogger(f"BunnyDNSProvider[{id}]")


### PR DESCRIPTION
Perform mapping between ALIAS (OctoDNS) and CNAME (BunnyDNS) records. Allows for the CNAME on root records in a zone.